### PR TITLE
CloudWatch Alarm・WAF・WAF LoggingをCloudFormationで追加

### DIFF
--- a/alm-waf-logging.yaml
+++ b/alm-waf-logging.yaml
@@ -1,0 +1,437 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: AWS-Study 
+
+# 課題提出用のテンプレート
+
+# VPC
+# Public Subnet x2
+# Private Subnet x2
+# InternetGateway
+# RouteTable
+# SecurityGroupEC2
+# SecurityGroupRDS
+# SecurityGroupALB
+# EC2
+# RDS Secrets Manager
+# RDS
+# DBSubnetGroup
+# ELB
+# ELBTargetGroup
+# ELBListener
+
+# SNS（通知先）
+# CloudWatch アラーム
+# WAF WebACL
+# WAFログ用 CloudWatch Logs
+# WAF Logging Configuration
+# Web ACL Association
+
+
+Resources:
+
+  # -------------------------
+  # VPC
+  # -------------------------
+  TestVPC: 
+    Type: AWS::EC2::VPC 
+    Properties: 
+      CidrBlock: 10.0.0.0/16
+      Tags: 
+        - Key: Name
+          Value: TEST-VPC
+
+  # -------------------------
+  # Public Subnet
+  # -------------------------
+  TestPublicSubNet1a:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: ap-northeast-1a
+      VpcId: !Ref TestVPC
+      CidrBlock: 10.0.0.0/24
+      Tags:
+        - Key: Name
+          Value: TEST-Public-SubNet1a
+
+  TestPublicSubNet1c:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: ap-northeast-1c
+      VpcId: !Ref TestVPC
+      CidrBlock: 10.0.1.0/24
+      Tags:
+        - Key: Name
+          Value: TEST-Public-SubNet1c
+
+  # -------------------------
+  # Private Subnet
+  # -------------------------
+  TestPrivateSubNet1a:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: ap-northeast-1a
+      VpcId: !Ref TestVPC
+      CidrBlock: 10.0.10.0/24
+      Tags:
+        - Key: Name
+          Value: TEST-Private-SubNet1a
+
+  TestPrivateSubNet1c:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: ap-northeast-1c
+      VpcId: !Ref TestVPC
+      CidrBlock: 10.0.11.0/24
+      Tags:
+        - Key: Name
+          Value: TEST-Private-SubNet1c
+
+  # -------------------------
+  # InternetGateway
+  # -------------------------
+  TestIGW:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: TEST-IGW
+
+  # -------------------------
+  # VPCGatewayAttachment
+  # -------------------------
+  AttachGateway: 
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref TestVPC
+      InternetGatewayId: !Ref TestIGW 
+
+  # -------------------------
+  # RouteTable
+  # -------------------------
+  TestRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref TestVPC
+      Tags:
+        - Key: Name
+          Value: TEST-RouteTable1
+
+  TestRoute1: #外部に出るための...
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref TestRouteTable1
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref TestIGW
+
+  # -------------------------
+  # 各サブネットとルートテーブルを関連付け（パブリックサブネット化）
+  # -------------------------
+  TestSubNetRoutTablAsso1: 
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref TestRouteTable1
+      SubnetId: !Ref TestPublicSubNet1a
+  
+  TestSubNetRoutTablAsso2: 
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref TestRouteTable1
+      SubnetId: !Ref TestPublicSubNet1c
+      
+  # ここまでがVPC
+
+  # -------------------------
+  # SecurityGroup for EC2
+  # -------------------------
+  TestSecurityGroupEC2:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: TEST-SecurityGroupEC2
+      GroupDescription: TEST-SecurityGroupEC2
+      VpcId: !Ref TestVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp                                   # SSH
+          CidrIp: 175.177.6.36/32                           # 固定IPアドレス
+          FromPort: 22
+          ToPort: 22
+        - IpProtocol: tcp                                   # HTTP
+          FromPort: 8080
+          ToPort: 8080
+          SourceSecurityGroupId: !Ref TestSecurityGroupALB
+      SecurityGroupEgress:                                  # アウトバウンド
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: TEST-SG-EC2
+
+  # -------------------------
+  #  SecurityGroup for RDS
+  # -------------------------
+  TestSecurityGroupRDS:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: AWS Study RDS
+      VpcId: !Ref TestVPC
+      SecurityGroupIngress:                                #インバウンド
+        - IpProtocol: tcp
+          FromPort: 3306                                   # mysqlのデフォルトが3306
+          ToPort: 3306
+          SourceSecurityGroupId: !Ref TestSecurityGroupEC2 # ここがミソ特定のSGに所属しているものから接続する方が汎用性高い
+      SecurityGroupEgress:                                 # アウトバウンド
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: TEST-SG-RDS                               #13 だと aws-study-rds-sg
+
+  # -------------------------
+  # SecurityGroup for ALB
+  # -------------------------
+  TestSecurityGroupALB:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: TEST-SecurityGroupALB
+      GroupDescription: TEST-SecurityGroupALB
+      VpcId: !Ref TestVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: TEST-SG-ALB
+
+  # -------------------------
+  # EC2
+  # -------------------------
+  TestEC2Instance: 
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Sub "resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+      InstanceType: t2.micro 
+      InstanceInitiatedShutdownBehavior: stop 
+      KeyName: aws-study-key            # キーペア（作成済みのキーペアを指定）
+      Tenancy: default    
+      NetworkInterfaces:   
+        - AssociatePublicIpAddress: "true"
+          DeviceIndex: "0"
+          SubnetId: !Ref TestPublicSubNet1a  
+          GroupSet:
+            - !Ref TestSecurityGroupEC2        
+      
+      BlockDeviceMappings:              # ストレージの設定
+        - DeviceName: /dev/xvda         # デバイス名
+          Ebs:
+            VolumeType: gp2             # ボリュームタイプ
+            DeleteOnTermination: true   # インスタンス終了時に削除するのか
+            VolumeSize: 10              # ディスクサイズ（GiB）
+      UserData: !Base64 |               # 構築後に実行するコマンド #下はhostname 変更コマンド
+        sudo hostnamectl set-hostname TEST-LINUX-INSTANCE 
+      Tags:                 
+        - Key: Name
+          Value: TEST-EC2
+
+  EipTestServer:                        # Elastic IP アドレス作成
+    Type: AWS::EC2::EIP
+    Properties:
+      InstanceId: !Ref TestEC2Instance
+
+  # -------------------------
+  # RDS Secrets Manager
+  # -------------------------
+  RDSSecret:                            # ここでRDSのパスワードとなるランダム文字列を生成
+    Type: "AWS::SecretsManager::Secret"
+    Properties:
+      Name: "RDSSecret"
+      Description: "RDS password for my RDS instance"
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "admin"}'
+        GenerateStringKey: "password"
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+
+  # -------------------------
+  # RDS
+  # -------------------------
+  TestRDS:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      AllocatedStorage: 20              # 容量GB
+      AllowMajorVersionUpgrade: false   # デフォ。mysqlのEngineVersion　8.0.の部分。大きく変わるので
+      AutoMinorVersionUpgrade: true     # 41の部分。セキュリティーが上がるので積極的に
+      DBInstanceClass: db.t4g.micro
+      Port: 3306                        # デフォ
+      StorageType: gp2                  # 13だとgp3 
+      BackupRetentionPeriod: 1          # 18:29 保存日数
+      MasterUsername: admin
+      MasterUserPassword: !Sub '{{resolve:secretsmanager:${RDSSecret}:SecretString:password}}' # Secrets Managerのランダム文字列を間接的に参照
+      PreferredBackupWindow: 15:00-16:00
+      PreferredMaintenanceWindow: sun:18:00-sun:19:00
+      DBName: awsstudy
+      Engine: mysql
+      EngineVersion: 8.0.41             #13は8.0.39
+      LicenseModel: general-public-license
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      VPCSecurityGroups:
+        - !Ref TestSecurityGroupRDS
+      Tags:
+        - Key: Name
+          Value: TEST-RDS
+  
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Created from the RDS Management Console #あまり気にしなくていい
+      SubnetIds:                        # プライベートサブネットを参照するよう変更
+        - !Ref TestPrivateSubNet1a
+        - !Ref TestPrivateSubNet1c
+
+  # -------------------------
+  # ELB
+  # -------------------------
+  TestELB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: TEST-ELB
+      SecurityGroups:
+        - !Ref TestSecurityGroupALB
+      Subnets:
+        - !Ref TestPublicSubNet1a
+        - !Ref TestPublicSubNet1c
+      Tags:
+        - Key: Name
+          Value: TEST-ELB
+
+  TestELBTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: TEST-ELB-TG
+      Port: 80
+      Protocol: HTTP
+      VpcId: !Ref TestVPC
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      HealthCheckTimeoutSeconds: 5
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: "/"
+      HealthCheckPort: "traffic-port"
+      HealthCheckIntervalSeconds: 10
+      Matcher:
+        HttpCode: 200
+      Tags:
+        - Key: Name
+          Value: TEST-ELB-TG
+      Targets:
+        - Id : !Ref TestEC2Instance
+          Port: 8080
+
+  TestELBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref TestELB
+      DefaultActions:
+        - TargetGroupArn: !Ref TestELBTargetGroup
+          Type: forward
+      Port: 80
+      Protocol: HTTP
+
+
+
+  # -------------------------
+  # SNS（通知先）
+  # -------------------------
+  AlarmTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: alarm-topic
+
+  # -------------------------
+  # CloudWatch アラーム
+  # -------------------------
+  CPUAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: EC2-CPU-Alarm
+      Namespace: AWS/EC2
+      MetricName: CPUUtilization
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref TestEC2Instance
+      AlarmActions:
+        - !Ref AlarmTopic
+
+  # -------------------------
+  # WAF WebACL
+  # -------------------------
+  WebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: aws-study-acl
+
+      Scope: REGIONAL
+
+      DefaultAction:
+        Allow: {}
+
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: awsStudyACL
+        SampledRequestsEnabled: true
+
+      Rules:
+        - Name: AWS-AWSManagedRulesCommonRuleSet
+          Priority: 1
+
+          OverrideAction:
+            None: {}
+
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: commonRules
+
+  # -------------------------
+  # WAFログ用 CloudWatch Logs
+  # -------------------------
+  WAFLogGroup:
+    Type: AWS::Logs::LogGroup
+
+    Properties:
+      LogGroupName: aws-waf-logs-study
+      RetentionInDays: 7
+
+  # -------------------------
+  # WAF Logging Configuration
+  # -------------------------
+  WAFLogging:
+    Type: AWS::WAFv2::LoggingConfiguration
+
+    DependsOn:
+      - WAFLogGroup
+
+    Properties:
+      ResourceArn: !GetAtt WebACL.Arn
+
+      LogDestinationConfigs:
+        - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:aws-waf-logs-study
+
+  # -------------------------
+  # Web ACL Association
+  # -------------------------
+  WebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref TestELB
+      WebACLArn: !GetAtt WebACL.Arn


### PR DESCRIPTION
## 実装内容

- CloudWatch Alarm（EC2 CPU使用率監視）を追加
- SNS Topicを作成し、アラーム通知先を設定
- AWS WAF WebACLを追加
- CloudWatch Logs用のロググループを追加
- CloudWatch Logsへログ出力するためのWAF Logging Configurationを追加
- ALBとWebACLを関連付ける設定を追加

## 動作確認

#### 1. ALB動作確認

- ALBのDNS名へアクセスし、htmlテストページ「AWS Study OK」が表示されることを確認（今回は、作業効率化のため過去作成したアプリ起動ではなくApacheのインストール&起動。）

・Apache起動
<img width="1440" height="900" alt="(1) terminal -1 2026-06-03 22 59 16" src="https://github.com/user-attachments/assets/7a3cb946-a583-4631-94e5-8800e6ab2a26" />
<img width="1440" height="900" alt="(2) terminal -2 2026-06-03 22 59 28" src="https://github.com/user-attachments/assets/30abf86f-2858-4fc3-b23e-f0d832d34e69" />


・DNS名アクセス①
<img width="1440" height="900" alt="(4) DNS 2026-06-03 22 09 21" src="https://github.com/user-attachments/assets/92f3f596-a74e-4dad-8151-f0c60c596b30" />

・DNS名アクセス② DNS名/?id='or1=1 の実行
<img width="1440" height="900" alt="(5) DNS id 2026-06-03 22 52 46" src="https://github.com/user-attachments/assets/7d505c6f-56f8-4a23-bbd8-7ab6a44e1ca3" />

#### 2.WAFログ出力確認

- CloudWatch LogsにWAFログが出力されることを確認
- ALBへの通常アクセス時にALLOWログが出力されることを確認
<img width="1440" height="900" alt="log allow 2026-05-29 23 57 35" src="https://github.com/user-attachments/assets/0ad9c25b-a0df-4457-aa9e-e5264bf3858c" />



#### 3. WAFルールによるBLOCK確認

- テスト用の不正リクエストを送信
- CloudWatch Logs上でBLOCKログが出力されることを確認
<img width="1440" height="900" alt="(8) log event -1 2026-06-03 22 56 22" src="https://github.com/user-attachments/assets/bb996ade-e396-4adb-a791-262823247ff2" />
<img width="1440" height="900" alt="(9) log event -2 2026-06-03 22 56 31" src="https://github.com/user-attachments/assets/ce7b4917-752b-41e4-a325-a43c785219f3" />
<img width="1440" height="900" alt="(10) log event -3 2026-06-03 22 56 38" src="https://github.com/user-attachments/assets/c66f4cb6-c7f9-491a-bd2d-d1fd4f483e6f" />


## 工夫した点・学んだこと

- スタック作成時のエラーについて。WAF Logging Configuration設定時にARN関連のエラーが発生したため、ARNの構造やCloudFormationの !Ref / !Sub / !GetAtt の違いについて理解を深めました
- ログが作られない事象発生。WAFログをCloudWatch Logsへ連携するために、WebACLとALBの関連付け（WebACLAssociation）が必要であることを学びました
- CloudWatch Logs上でWAFログのJSON形式におけるALLOW/BLOCK判定表示について学びました
